### PR TITLE
Object Manipulation Instead of Re-Query

### DIFF
--- a/app/scripts/controllers/links.js
+++ b/app/scripts/controllers/links.js
@@ -78,22 +78,16 @@ angular.module('linkDumpApp')
     }
 
     //Get the title of a link
-    $scope.getTitle = function(index) {
-      //Get the index in the order that we need it
-      index = $scope.dumps.length - index - 1;
+    $scope.getTitle = function(dump, index) {
 
       //Get the response from noembed
-      $http.get("http://dev.kondeo.com/api/title-scraper.php?q=" + $scope.dumps[index].content)
+      $http.get("http://dev.kondeo.com/api/title-scraper.php?q=" + dump.content)
         .then(function(response) {
 
             //Get the document
-            var element = document.getElementById("linkTitle-" + $scope.dumps[index].content);
+            var element = document.getElementById("linkTitle-" + index);
 
             element.innerHTML = response.data.title;
-
-            //set the title attribute of the dump
-            $scope.dumps[index].title = response.data.title;
-
         });
     }
 
@@ -196,8 +190,6 @@ angular.module('linkDumpApp')
 
                 //Add new dump to dump array
                 $scope.dumps.unshift(data);
-                //Get new title
-                $scope.getTitle($scope.dumps.length - 1);
               },
               function(err) {
                 Materialize.toast(err.data.msg, 3000);

--- a/app/scripts/controllers/links.js
+++ b/app/scripts/controllers/links.js
@@ -92,59 +92,53 @@ angular.module('linkDumpApp')
     }
 
     //Get a sce trusted embedly bandcamp
-    $scope.getEmbed = function(index) {
-      //Get the index in the order that we need it
-      index = $scope.dumps.length - index - 1;
-
+    $scope.getEmbed = function(dump) {
       //Get the response from noembed
-      $http.get("https://noembed.com/embed?url=" + $scope.dumps[index].content + "&nowrap=on")
+      $http.get("https://noembed.com/embed?url=" + dump.content + "&nowrap=on")
         .then(function(response) {
 
           //Check for no error
           if (!response.data.error) {
             //Get the document
-            var element = document.getElementById("embed-" + $scope.dumps[index].content);
+            var element = document.getElementById("embed-" + dump.content);
 
             element.innerHTML = $sce.trustAsHtml(response.data.html);
             // say the dump has been lazy loaded
-            $scope.dumps[index].lazyEmbed = true;
+            dump.lazyEmbed = true;
           } else {
             //Get the response from embedly
-            $http.get("http://api.embed.ly/1/oembed?key=" + embedlyKey + "&url=" + $scope.dumps[index].content)
+            $http.get("http://api.embed.ly/1/oembed?key=" + embedlyKey + "&url=" + dump.content)
               .then(function(response) {
                 //Our response from embedly
                 //Get the document
-                var element = document.getElementById("embed-" + $scope.dumps[index].content);
+                var element = document.getElementById("embed-" + dump.content);
 
                 element.innerHTML = $sce.trustAsHtml(response.data.html);
                 // say the dump has been lazy loaded
-                $scope.dumps[index].lazyEmbed = true;
+                dump.lazyEmbed = true;
               });
           }
         });
     }
 
     //get a sce trusted soundcloud thingy
-    $scope.getSoundCloud = function(index) {
+    $scope.getSoundCloud = function(dump) {
       //Used this
       //https://developers.soundcloud.com/docs/api/guide#playing
 
-      //Get the index in the order that we need it
-      index = $scope.dumps.length - index - 1;
-
       SC.get('/resolve', {
-        url: $scope.dumps[index].content
+        url: dump.content
       }, function(track) {
 
         //Get the document
-        var element = document.getElementById("scWidget-" + $scope.dumps[index].content);
+        var element = document.getElementById("scWidget-" + dump.content);
 
         element.src = $sce.trustAsResourceUrl("https://w.soundcloud.com/player/?url=https%3A" +
           track.uri.substring(track.uri.indexOf("//api.soundcloud.com")) +
           "&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true");
 
         // say the dump has been lazy loaded
-        $scope.dumps[index].lazyEmbed = true;
+        dump.lazyEmbed = true;
 
       });
     }

--- a/app/scripts/controllers/links.js
+++ b/app/scripts/controllers/links.js
@@ -72,9 +72,9 @@ angular.module('linkDumpApp')
     }
 
     //Get the title of a link
-    $scope.getTitle = function(index) {
+    $scope.getTitle = function(dump) {
       //Get the index in the order that we need it
-      index = $scope.dumps.length - index - 1;
+      var index = $scope.dumps.indexOf(dump);
 
       //Get the response from noembed
       $http.get("https://noembed.com/embed?url=" + $scope.dumps[index].content)
@@ -206,8 +206,6 @@ angular.module('linkDumpApp')
 
                 //Add new dump to dump array
                 $scope.dumps.unshift(data);
-                //Get new title
-                $scope.getTitle($scope.dumps.length - 1);
               },
               function(data, status) {
                 Materialize.toast(data.msg, 3000);

--- a/app/scripts/controllers/links.js
+++ b/app/scripts/controllers/links.js
@@ -204,8 +204,10 @@ angular.module('linkDumpApp')
                 //Inform user of the dump
                 Materialize.toast("Dumped!", 3000);
 
-                //Re-get all ouf our links!
-                $scope.getDumps();
+                //Add new dump to dump array
+                $scope.dumps.unshift(data);
+                //Get new title
+                $scope.getTitle($scope.dumps.length - 1);
               },
               function(data, status) {
                 Materialize.toast(data.msg, 3000);
@@ -227,10 +229,12 @@ angular.module('linkDumpApp')
         "id": dump._id
       };
 
+      var index = $scope.dumps.indexOf(dump);
+
       //Save the link
       Dump.delete(remJson, function(data, status) {
-        //Re-get all ouf our links!
-        $scope.getDumps();
+        //Splice off dump we dont want
+        $scope.dumps.splice(index, 1);
 
         //Inform user
         Materialize.toast("Deleted " + data.content + "!", 3000);

--- a/app/scripts/controllers/links.js
+++ b/app/scripts/controllers/links.js
@@ -72,9 +72,9 @@ angular.module('linkDumpApp')
     }
 
     //Get the title of a link
-    $scope.getTitle = function(dump) {
+    $scope.getTitle = function(index) {
       //Get the index in the order that we need it
-      var index = $scope.dumps.indexOf(dump);
+      index = $scope.dumps.length - index - 1;
 
       //Get the response from noembed
       $http.get("https://noembed.com/embed?url=" + $scope.dumps[index].content)
@@ -206,6 +206,8 @@ angular.module('linkDumpApp')
 
                 //Add new dump to dump array
                 $scope.dumps.unshift(data);
+                //Get new title
+                $scope.getTitle($scope.dumps.length - 1);
               },
               function(data, status) {
                 Materialize.toast(data.msg, 3000);

--- a/app/views/links.html
+++ b/app/views/links.html
@@ -41,13 +41,13 @@
                     || (dump.content.indexOf('https://www.youtube.com/watch?v=') > -1)
                     || (dump.content.indexOf('https://vimeo.com/') > -1)"
                     id = "embed-{{dump.content}}"
-                    in-view = "$inview && !dump.lazyEmbed && getEmbed($index)">
+                    in-view = "$inview && !dump.lazyEmbed && getEmbed(dump)">
                 </div>
 
                 <!-- display soundcloud if it is a soundcloud link (Using their own api) -->
                 <div ng-if = "dump.content.indexOf('https://soundcloud.com/') > -1">
                     <iframe id = "scWidget-{{dump.content}}" width="100%" height="400" scrolling="no"
-                    in-view = "$inview &&  !dump.lazyEmbed && getSoundCloud($index)" frameborder="no">
+                    in-view = "$inview &&  !dump.lazyEmbed && getSoundCloud(dump)" frameborder="no">
                     </iframe>
                 </div>
 

--- a/app/views/links.html
+++ b/app/views/links.html
@@ -56,7 +56,7 @@
                 <a id = "linkTitle-{{dump.content}}"
                 href="{{dump.content}}" target="_blank"
                 class = "dropURL"
-                ng-init = "getTitle(dump)">
+                ng-init = "getTitle($index)">
                 {{dump.content}}
                 </a>
 

--- a/app/views/links.html
+++ b/app/views/links.html
@@ -53,10 +53,10 @@
 
                 <!-- Get our favicon and link title -->
                 <img ng-src="{{dump.content | favicon}}" alt="Drop Icon" class = "dropFavicon">
-                <a id = "linkTitle-{{dump.content}}"
+                <a id = "linkTitle-{{$index}}"
                 href="{{dump.content}}" target="_blank"
                 class = "dropURL"
-                ng-init = "getTitle($index)">
+                ng-init = "getTitle(dump, $index)">
                 {{dump.content}}
                 </a>
 

--- a/app/views/links.html
+++ b/app/views/links.html
@@ -56,7 +56,7 @@
                 <a id = "linkTitle-{{dump.content}}"
                 href="{{dump.content}}" target="_blank"
                 class = "dropURL"
-                ng-init = "getTitle($index)">
+                ng-init = "getTitle(dump)">
                 {{dump.content}}
                 </a>
 


### PR DESCRIPTION
For some reason, every time a dump was created or deleted, the backend was being queried for ALL dumps. This causes a complete refresh in the DOM, causing slow load times and high internet usage. Also drains the battery a ton, due to ~4mb download and upload every time page is refreshed.

I have changed everything to local object manipulation, which is much more sensible. Objects will now be spliced and upshifted when removing/adding to object array. This will solve the DOM reload problem, will remove the un-discovered bug of high load times and alleviate extreme backend load/crashes.

In addition, the app now doesn’t do backwards array sorting and reverse index search. Uses indexOf(dump) which limits the backwards thinking we have to do. This makes more sense.

Closes #32 

Look at how fast adding links is now:
![untitled recording 6](https://cloud.githubusercontent.com/assets/7751154/9864764/1fab35b6-5b02-11e5-891e-518592a7c92f.gif)
